### PR TITLE
Update Global.css

### DIFF
--- a/frontend/src/stylesheets/Global.css
+++ b/frontend/src/stylesheets/Global.css
@@ -14,7 +14,7 @@ nav {
 
 body {
 	font-family: "Nunito Sans", sans-serif;
-	background-color: #fff;
+/* 	background-color: #fff; */
 }
 
 a {


### PR DESCRIPTION
I would recommend establishing the background color of a page not on the global css, this can cause errors. For example the sign up page currently has the Axe error "Element's background color could not be determined because it's partially obscured by another element" but when you get rid of the background styling the error is eliminated and the background stays white.